### PR TITLE
Simplify StatusCodeError's message

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,5 +1,28 @@
 'use strict';
 
+var MESSAGES = require('http').STATUS_CODES;
+
+function buildMessage(statusCode) {
+
+    var prefix = statusCode;
+    var padding = ' - ';
+    var suffix = MESSAGES[statusCode];
+
+    // if node's http lib does not define a message default to the generic
+    // message defined in Section 10 of RFC 2616
+    if (!suffix) {
+        /* eslint-disable yoda */
+        if (100 <= statusCode && statusCode < 200) suffix = 'Informational';
+        else if (200 <= statusCode && statusCode < 300) suffix = 'OK';
+        else if (300 <= statusCode && statusCode < 400) suffix = 'Redirection';
+        else if (400 <= statusCode && statusCode < 500) suffix = 'Client Error';
+        else if (500 <= statusCode && statusCode < 600) suffix = 'Server Error';
+        else return prefix;
+        /* eslint-enable yoda */
+    }
+
+    return prefix + padding + suffix;
+}
 
 function RequestError(cause, options, response) {
 
@@ -23,7 +46,7 @@ function StatusCodeError(statusCode, body, options, response) {
 
     this.name = 'StatusCodeError';
     this.statusCode = statusCode;
-    this.message = 'Request status code was not 2xx';
+    this.message = this.buildMessage(statusCode, body, options, response);
     this.error = body; // legacy attribute
     this.options = options;
     this.response = response;
@@ -35,6 +58,7 @@ function StatusCodeError(statusCode, body, options, response) {
 }
 StatusCodeError.prototype = Object.create(Error.prototype);
 StatusCodeError.prototype.constructor = StatusCodeError;
+StatusCodeError.prototype.buildMessage = buildMessage;
 
 
 function TransformError(cause, options, response) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -23,7 +23,7 @@ function StatusCodeError(statusCode, body, options, response) {
 
     this.name = 'StatusCodeError';
     this.statusCode = statusCode;
-    this.message = statusCode + ' - ' + (JSON && JSON.stringify ? JSON.stringify(body) : body);
+    this.message = 'Request status code was not 2xx';
     this.error = body; // legacy attribute
     this.options = options;
     this.response = response;

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -4,7 +4,7 @@ var MESSAGES = require('http').STATUS_CODES;
 
 function buildMessage(statusCode) {
 
-    var prefix = statusCode;
+    var prefix = String(statusCode);
     var padding = ' - ';
     var suffix = MESSAGES[statusCode];
 

--- a/test/spec/errors.js
+++ b/test/spec/errors.js
@@ -6,8 +6,8 @@ describe('StatusCodeError', function () {
 
     it('should use http message string for errors', function () {
 
-        var e = new errors.StatusCodeError(301);
-        expect(e.message).to.eql('301 - Found');
+        var e = new errors.StatusCodeError(302);
+        expect(e.message).to.eql('302 - Found');
 
         e = new errors.StatusCodeError(400);
         expect(e.message).to.eql('400 - Bad Request');

--- a/test/spec/errors.js
+++ b/test/spec/errors.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var errors = require('../../errors');
+
+describe('StatusCodeError', function () {
+
+    it('should use http message string for errors', function () {
+
+        var e = new errors.StatusCodeError(301);
+        expect(e.message).to.eql('301 - Found');
+
+        e = new errors.StatusCodeError(400);
+        expect(e.message).to.eql('400 - Bad Request');
+
+        e = new errors.StatusCodeError(502);
+        expect(e.message).to.eql('502 - Bad Gateway');
+
+    });
+
+    it('should default to generic suffix for unknown status codes', function () {
+
+        var e = new errors.StatusCodeError(160);
+        expect(e.message).to.eql('160 - Informational');
+
+        e = new errors.StatusCodeError(260);
+        expect(e.message).to.eql('260 - OK');
+
+        e = new errors.StatusCodeError(360);
+        expect(e.message).to.eql('360 - Redirection');
+
+        e = new errors.StatusCodeError(440);
+        expect(e.message).to.eql('440 - Client Error');
+
+        e = new errors.StatusCodeError(550);
+        expect(e.message).to.eql('550 - Server Error');
+
+    });
+
+    it('should default to just status code if it is not in range [100, 599]', function () {
+
+        var e = new errors.StatusCodeError(99);
+        expect(e.message).to.eql('99');
+
+        e = new errors.StatusCodeError(600);
+        expect(e.message).to.eql('600');
+
+    });
+
+});

--- a/test/spec/errors.js
+++ b/test/spec/errors.js
@@ -6,8 +6,8 @@ describe('StatusCodeError', function () {
 
     it('should use http message string for errors', function () {
 
-        var e = new errors.StatusCodeError(302);
-        expect(e.message).to.eql('302 - Found');
+        var e = new errors.StatusCodeError(304);
+        expect(e.message).to.eql('304 - Not Modified');
 
         e = new errors.StatusCodeError(400);
         expect(e.message).to.eql('400 - Bad Request');

--- a/test/spec/plumbing.js
+++ b/test/spec/plumbing.js
@@ -5,8 +5,6 @@ var _ = require('lodash'),
     errors = require('../../errors'),
     plumbing = require('../../');
 
-var STATUS_CODE_MESSAGE = 'Request status code was not 2xx';
-
 describe('Promise-Core\'s Plumbing', function () {
 
     it('should verify the options', function () {
@@ -357,7 +355,35 @@ describe('Promise-Core\'s Plumbing', function () {
                 .catch(errors.StatusCodeError, function (err) {
                     expect(err.name).to.eql('StatusCodeError');
                     expect(err.statusCode).to.eql(404);
-                    expect(err.message).to.eql(STATUS_CODE_MESSAGE);
+                    expect(err.message).to.eql('404 - Not Found');
+                    expect(err.error).to.eql(response.body);
+                    expect(err.options).to.eql(context._rp_options);
+                    expect(err.response).to.eql(response);
+                });
+
+        });
+
+        it('that rejects a non-2xx response in simple mode', function () {
+
+            var context = {};
+            pl.init.call(context, {});
+
+            var response = {
+                statusCode: 404,
+                body: {
+                    a: 'b'
+                }
+            };
+            pl.callback.call(context, null, response, response.body);
+
+            return context._rp_promise
+                .then(function () {
+                    throw new Error('Expected promise to be rejected.');
+                })
+                .catch(errors.StatusCodeError, function (err) {
+                    expect(err.name).to.eql('StatusCodeError');
+                    expect(err.statusCode).to.eql(404);
+                    expect(err.message).to.eql('404 - Not Found');
                     expect(err.error).to.eql(response.body);
                     expect(err.options).to.eql(context._rp_options);
                     expect(err.response).to.eql(response);
@@ -603,7 +629,7 @@ describe('Promise-Core\'s Plumbing', function () {
                     expect(err instanceof errors.StatusCodeError).to.eql(true);
                     expect(err.name).to.eql('StatusCodeError');
                     expect(err.statusCode).to.eql(404);
-                    expect(err.message).to.eql(STATUS_CODE_MESSAGE);
+                    expect(err.message).to.eql('404 - Not Found');
                     expect(err.error).to.eql(res.body);
                     expect(err.options).to.eql(context._rp_options);
                     expect(err.response).to.eql(JSON.stringify(res.body) + ' - ' + JSON.stringify(res) + ' - false');
@@ -671,7 +697,7 @@ describe('Promise-Core\'s Plumbing', function () {
                 .catch(errors.StatusCodeError, function (err) {
                     expect(err.name).to.eql('StatusCodeError');
                     expect(err.statusCode).to.eql(404);
-                    expect(err.message).to.eql(STATUS_CODE_MESSAGE);
+                    expect(err.message).to.eql('404 - Not Found');
                     expect(err.error).to.eql(res.body);
                     expect(err.options).to.eql(context._rp_options);
                     expect(err.response).to.eql(JSON.stringify(res.body) + ' - ' + JSON.stringify(res) + ' - false');
@@ -769,7 +795,7 @@ describe('Promise-Core\'s Plumbing', function () {
                 .catch(errors.StatusCodeError, function (err) {
                     expect(err.name).to.eql('StatusCodeError');
                     expect(err.statusCode).to.eql(404);
-                    expect(err.message).to.eql(STATUS_CODE_MESSAGE);
+                    expect(err.message).to.eql('404 - Not Found');
                     expect(err.error).to.eql(res.body);
                     expect(err.options).to.eql(context._rp_options);
                     expect(err.response).to.eql(res);
@@ -945,7 +971,7 @@ describe('Promise-Core\'s Plumbing', function () {
                 .catch(errors.StatusCodeError, function (err) {
                     expect(err.name).to.eql('StatusCodeError');
                     expect(err.statusCode).to.eql(404);
-                    expect(err.message).to.eql(STATUS_CODE_MESSAGE);
+                    expect(err.message).to.eql('404 - Not Found');
                     expect(err.error).to.eql(res.body);
                     expect(err.options).to.eql(context._rp_options);
                     expect(err.response).to.eql(res);

--- a/test/spec/plumbing.js
+++ b/test/spec/plumbing.js
@@ -363,34 +363,6 @@ describe('Promise-Core\'s Plumbing', function () {
 
         });
 
-        it('that rejects a non-2xx response in simple mode', function () {
-
-            var context = {};
-            pl.init.call(context, {});
-
-            var response = {
-                statusCode: 404,
-                body: {
-                    a: 'b'
-                }
-            };
-            pl.callback.call(context, null, response, response.body);
-
-            return context._rp_promise
-                .then(function () {
-                    throw new Error('Expected promise to be rejected.');
-                })
-                .catch(errors.StatusCodeError, function (err) {
-                    expect(err.name).to.eql('StatusCodeError');
-                    expect(err.statusCode).to.eql(404);
-                    expect(err.message).to.eql('404 - Not Found');
-                    expect(err.error).to.eql(response.body);
-                    expect(err.options).to.eql(context._rp_options);
-                    expect(err.response).to.eql(response);
-                });
-
-        });
-
         it('that resolves a non-2xx response in non-simple mode', function (done) {
 
             var context = {};

--- a/test/spec/plumbing.js
+++ b/test/spec/plumbing.js
@@ -5,6 +5,7 @@ var _ = require('lodash'),
     errors = require('../../errors'),
     plumbing = require('../../');
 
+var STATUS_CODE_MESSAGE = 'Request status code was not 2xx';
 
 describe('Promise-Core\'s Plumbing', function () {
 
@@ -336,7 +337,7 @@ describe('Promise-Core\'s Plumbing', function () {
 
         });
 
-        it('that rejects a non-2xx response in simple mode', function (done) {
+        it('that rejects a non-2xx response in simple mode', function () {
 
             var context = {};
             pl.init.call(context, {});
@@ -349,19 +350,17 @@ describe('Promise-Core\'s Plumbing', function () {
             };
             pl.callback.call(context, null, response, response.body);
 
-            context._rp_promise
+            return context._rp_promise
                 .then(function () {
-                    done(new Error('Expected promise to be rejected.'));
+                    throw new Error('Expected promise to be rejected.');
                 })
-                .catch(function (err) {
-                    expect(err instanceof errors.StatusCodeError).to.eql(true);
+                .catch(errors.StatusCodeError, function (err) {
                     expect(err.name).to.eql('StatusCodeError');
                     expect(err.statusCode).to.eql(404);
-                    expect(err.message).to.eql('404 - {"a":"b"}');
+                    expect(err.message).to.eql(STATUS_CODE_MESSAGE);
                     expect(err.error).to.eql(response.body);
                     expect(err.options).to.eql(context._rp_options);
                     expect(err.response).to.eql(response);
-                    done();
                 });
 
         });
@@ -579,7 +578,7 @@ describe('Promise-Core\'s Plumbing', function () {
 
         });
 
-        it('that applies the transform function to non-2xx responses in simple mode', function (done) {
+        it('that applies the transform function to non-2xx responses in simple mode', function () {
 
             var context = {};
             pl.init.call(context, {
@@ -596,19 +595,18 @@ describe('Promise-Core\'s Plumbing', function () {
             };
             pl.callback.call(context, null, res, res.body);
 
-            context._rp_promise
+            return context._rp_promise
                 .then(function () {
-                    done(new Error('Expected promise to be rejected.'));
+                    throw new Error('Expected promise to be rejected.');
                 })
-                .catch(function (err) {
+                .catch(errors.StatusCodeError, function (err) {
                     expect(err instanceof errors.StatusCodeError).to.eql(true);
                     expect(err.name).to.eql('StatusCodeError');
                     expect(err.statusCode).to.eql(404);
-                    expect(err.message).to.eql('404 - {"a":"b"}');
+                    expect(err.message).to.eql(STATUS_CODE_MESSAGE);
                     expect(err.error).to.eql(res.body);
                     expect(err.options).to.eql(context._rp_options);
                     expect(err.response).to.eql(JSON.stringify(res.body) + ' - ' + JSON.stringify(res) + ' - false');
-                    done();
                 });
 
         });
@@ -649,7 +647,7 @@ describe('Promise-Core\'s Plumbing', function () {
 
         });
 
-        it('that applies the transform function to non-2xx responses in simple mode which returns a promise', function (done) {
+        it('that applies the transform function to non-2xx responses in simple mode which returns a promise', function () {
 
             var context = {};
             pl.init.call(context, {
@@ -666,19 +664,17 @@ describe('Promise-Core\'s Plumbing', function () {
             };
             pl.callback.call(context, null, res, res.body);
 
-            context._rp_promise
+            return context._rp_promise
                 .then(function () {
-                    done(new Error('Expected promise to be rejected.'));
+                    throw new Error('Expected promise to be rejected.');
                 })
-                .catch(function (err) {
-                    expect(err instanceof errors.StatusCodeError).to.eql(true);
+                .catch(errors.StatusCodeError, function (err) {
                     expect(err.name).to.eql('StatusCodeError');
                     expect(err.statusCode).to.eql(404);
-                    expect(err.message).to.eql('404 - {"a":"b"}');
+                    expect(err.message).to.eql(STATUS_CODE_MESSAGE);
                     expect(err.error).to.eql(res.body);
                     expect(err.options).to.eql(context._rp_options);
                     expect(err.response).to.eql(JSON.stringify(res.body) + ' - ' + JSON.stringify(res) + ' - false');
-                    done();
                 });
 
         });
@@ -748,7 +744,7 @@ describe('Promise-Core\'s Plumbing', function () {
 
         });
 
-        it('that does not apply the transform function to non-2xx responses for simple = true and transform2xxOnly = false', function (done) {
+        it('that does not apply the transform function to non-2xx responses for simple = true and transform2xxOnly = false', function () {
 
             var context = {};
             pl.init.call(context, {
@@ -766,19 +762,17 @@ describe('Promise-Core\'s Plumbing', function () {
             };
             pl.callback.call(context, null, res, res.body);
 
-            context._rp_promise
+            return context._rp_promise
                 .then(function () {
-                    done(new Error('Expected promise to be rejected.'));
+                    throw new Error('Expected promise to be rejected.');
                 })
-                .catch(function (err) {
-                    expect(err instanceof errors.StatusCodeError).to.eql(true);
+                .catch(errors.StatusCodeError, function (err) {
                     expect(err.name).to.eql('StatusCodeError');
                     expect(err.statusCode).to.eql(404);
-                    expect(err.message).to.eql('404 - {"a":"b"}');
+                    expect(err.message).to.eql(STATUS_CODE_MESSAGE);
                     expect(err.error).to.eql(res.body);
                     expect(err.options).to.eql(context._rp_options);
                     expect(err.response).to.eql(res);
-                    done();
                 });
 
         });
@@ -925,7 +919,7 @@ describe('Promise-Core\'s Plumbing', function () {
 
         });
 
-        it('that ignores the transform option for non-2xx responses if it is not a function', function (done) {
+        it('that ignores the transform option for non-2xx responses if it is not a function', function () {
 
             // IMHO input validation should reject this but behavior is kept this way for backwards compatibility.
 
@@ -944,19 +938,17 @@ describe('Promise-Core\'s Plumbing', function () {
             };
             pl.callback.call(context, null, res, res.body);
 
-            context._rp_promise
+            return context._rp_promise
                 .then(function () {
-                    done(new Error('Expected promise to be rejected.'));
+                    throw new Error('Expected promise to be rejected.');
                 })
-                .catch(function (err) {
-                    expect(err instanceof errors.StatusCodeError).to.eql(true);
+                .catch(errors.StatusCodeError, function (err) {
                     expect(err.name).to.eql('StatusCodeError');
                     expect(err.statusCode).to.eql(404);
-                    expect(err.message).to.eql('404 - undefined');
+                    expect(err.message).to.eql(STATUS_CODE_MESSAGE);
                     expect(err.error).to.eql(res.body);
                     expect(err.options).to.eql(context._rp_options);
                     expect(err.response).to.eql(res);
-                    done();
                 });
 
         });


### PR DESCRIPTION
StatusCodeError error appends the stringified body to its error property. This could potentially leak sensitive information into error logs if the body contains sensitive information.

This is currently a work in progress, ~~need some feedback as to what the error message should be~~ going to use status code messages as per [comment](https://github.com/request/promise-core/issues/1#issuecomment-294094516)
ref: #1