### PR TITLE
Use lodash per-method packages

### DIFF
--- a/configure/request-next.js
+++ b/configure/request-next.js
@@ -1,9 +1,8 @@
 'use strict';
 
 var core = require('../'),
-    isArray = require('lodash/isArray'),
-    isFunction = require('lodash/isFunction'),
-    isObjectLike = require('lodash/isObjectLike');
+    isFunction = require('lodash.isfunction'),
+    isObjectLike = require('lodash.isobjectlike');
 
 
 module.exports = function (options) {
@@ -18,7 +17,7 @@ module.exports = function (options) {
         throw new TypeError(errorText + '.client');
     }
 
-    if (!isArray(options.expose) || options.expose.length === 0) {
+    if (!Array.isArray(options.expose) || options.expose.length === 0) {
         throw new TypeError(errorText + '.expose');
     }
 

--- a/configure/request2.js
+++ b/configure/request2.js
@@ -1,9 +1,8 @@
 'use strict';
 
 var core = require('../'),
-    isArray = require('lodash/isArray'),
-    isFunction = require('lodash/isFunction'),
-    isObjectLike = require('lodash/isObjectLike');
+    isFunction = require('lodash.isfunction'),
+    isObjectLike = require('lodash.isobjectlike');
 
 
 module.exports = function (options) {
@@ -18,7 +17,7 @@ module.exports = function (options) {
         throw new TypeError(errorText + '.request');
     }
 
-    if (!isArray(options.expose) || options.expose.length === 0) {
+    if (!Array.isArray(options.expose) || options.expose.length === 0) {
         throw new TypeError(errorText + '.expose');
     }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ var chalk = require('chalk');
 var rimraf = require('rimraf');
 var coveralls = require('gulp-coveralls');
 var eslint = require('gulp-eslint');
-var _ = require('lodash');
+var flatten = require('lodash.flatten');
 
 var chai = require('chai');
 global.expect = chai.expect;
@@ -27,7 +27,7 @@ gulp.task('dev', ['watch', 'validate']);
 
 gulp.task('watch', function () {
 
-    gulp.watch(_.flatten([
+    gulp.watch(flatten([
         paths.libJsFiles,
         paths.specFiles,
         paths.fixtureFiles,
@@ -36,7 +36,7 @@ gulp.task('watch', function () {
         'validate'
     ]);
 
-    gulp.watch(_.flatten([
+    gulp.watch(flatten([
         paths.eslintrc
     ]), [
         'lint'
@@ -50,7 +50,7 @@ gulp.task('validate', function (done) {
 
 gulp.task('lint', function () {
 
-    return gulp.src(_.flatten([
+    return gulp.src(flatten([
         paths.libJsFiles,
         paths.gulpfile,
         paths.specFiles,

--- a/lib/plumbing.js
+++ b/lib/plumbing.js
@@ -1,10 +1,10 @@
 'use strict';
 
 var errors = require('./errors.js'),
-    isFunction = require('lodash/isFunction'),
-    isObjectLike = require('lodash/isObjectLike'),
-    isString = require('lodash/isString'),
-    isUndefined = require('lodash/isUndefined');
+    isFunction = require('lodash.isfunction'),
+    isObjectLike = require('lodash.isobjectlike'),
+    isString = require('lodash.isstring'),
+    isUndefined = require('lodash.isundefined');
 
 
 module.exports = function (options) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,10 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "lodash": "^4.13.1"
+    "lodash.isfunction": "^3.0.8",
+    "lodash.isobjectlike": "^4.0.0",
+    "lodash.isstring": "^4.0.1",
+    "lodash.isundefined": "^3.0.1"
   },
   "peerDependencies": {
     "request": "^2.34"
@@ -50,6 +53,7 @@
     "gulp-eslint": "~2.1.0",
     "gulp-istanbul": "~1.0.0",
     "gulp-mocha": "~2.2.0",
+    "lodash.flatten": "^4.4.0",
     "node-version": "~1.0.0",
     "publish-please": "~2.1.4",
     "request": "^2.34.0",

--- a/test/spec/plumbing.js
+++ b/test/spec/plumbing.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _ = require('lodash'),
+var isFunction = require('lodash.isfunction'),
     Bluebird = require('bluebird'),
     errors = require('../../errors'),
     plumbing = require('../../');
@@ -62,8 +62,8 @@ describe('Promise-Core\'s Plumbing', function () {
 
             pl.init.call(context, {});
 
-            expect(_.isFunction(context._rp_promise.then)).to.eql(true);
-            expect(_.isFunction(context._rp_resolve)).to.eql(true);
+            expect(isFunction(context._rp_promise.then)).to.eql(true);
+            expect(isFunction(context._rp_resolve)).to.eql(true);
 
             context._rp_resolve();
 
@@ -82,8 +82,8 @@ describe('Promise-Core\'s Plumbing', function () {
             var context = {};
             pl.init.call(context, {});
 
-            expect(_.isFunction(context._rp_promise.then)).to.eql(true);
-            expect(_.isFunction(context._rp_reject)).to.eql(true);
+            expect(isFunction(context._rp_promise.then)).to.eql(true);
+            expect(isFunction(context._rp_reject)).to.eql(true);
 
             context._rp_reject(new Error('Rejected by test case'));
 
@@ -134,7 +134,7 @@ describe('Promise-Core\'s Plumbing', function () {
             var context = {};
             pl.init.call(context, {});
 
-            expect(_.isFunction(context._rp_options.callback)).to.eql(true);
+            expect(isFunction(context._rp_options.callback)).to.eql(true);
             delete context._rp_options.callback;
 
             expect(context._rp_options).to.eql({


### PR DESCRIPTION
The complete lodash package weighs in at about 5.1 MB, making it a very large production dependency. By using lodash's [per-method packages](https://www.npmjs.com/browse/keyword/lodash-modularized) instead, you can reduce the size of many node_modules folders out there.

I replaced `._isArray` with `Array.isArray()` as the former has been deprecated in favour of the latter.