### PR TITLE
Update lodash due to security

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "lodash": "^4.13.1"
+    "lodash": "^4.17.11"
   },
   "peerDependencies": {
     "request": "^2.34"


### PR DESCRIPTION
Prior versions of lodash have been compromised so you should force users to grab 4.17.11
All tests seem to still run locally. 