### PR TITLE
Implement `pause` option for resolving with stream

### DIFF
--- a/lib/plumbing.js
+++ b/lib/plumbing.js
@@ -37,6 +37,7 @@ module.exports = function (options) {
         self._rp_options.simple = requestOptions.simple !== false;
         self._rp_options.resolveWithFullResponse = requestOptions.resolveWithFullResponse === true;
         self._rp_options.transform2xxOnly = requestOptions.transform2xxOnly === true;
+        self._rp_options.pause = requestOptions.pause === true;
 
         self._rp_promise = new PromiseImpl(function (resolve, reject) {
             self._rp_resolve = resolve;
@@ -46,10 +47,15 @@ module.exports = function (options) {
             }
         });
 
-        self._rp_callbackOrig = requestOptions.callback;
-        requestOptions.callback = self.callback = function RP$callback(err, response, body) {
-            plumbing.callback.call(self, err, response, body);
-        };
+        if (self._rp_options.pause) {
+            self.on("error", plumbing.handleError);
+            self.on("response", plumbing.handleResponse);
+        } else {
+            self._rp_callbackOrig = requestOptions.callback;
+            requestOptions.callback = self.callback = function RP$callback(err, response, body) {
+                plumbing.callback.call(self, err, response, body);
+            };
+        }
 
         if (isString(requestOptions.method)) {
             requestOptions.method = requestOptions.method.toUpperCase();
@@ -95,6 +101,7 @@ module.exports = function (options) {
     plumbing.handleError = function (err, response) {
 
         var self = this;
+        plumbing.removeListeners.call(self);
 
         self._rp_reject(new errors.RequestError(err, self._rp_options, response));
 
@@ -103,12 +110,13 @@ module.exports = function (options) {
     plumbing.handleResponse = function (response, body) {
 
         var self = this;
+        plumbing.removeListeners.call(self);
 
         var is2xx = /^2/.test('' + response.statusCode);
 
         if (self._rp_options.simple && !is2xx) {
 
-            if (isFunction(self._rp_options.transform) && self._rp_options.transform2xxOnly === false) {
+            if (!self._rp_options.pause && isFunction(self._rp_options.transform) && self._rp_options.transform2xxOnly === false) {
 
                 (new PromiseImpl(function (resolve) {
                     resolve(self._rp_options.transform(body, response, self._rp_options.resolveWithFullResponse)); // transform may return a Promise
@@ -123,6 +131,11 @@ module.exports = function (options) {
             } else {
                 self._rp_reject(new errors.StatusCodeError(response.statusCode, body, self._rp_options, response));
             }
+
+        } else if (self._rp_options.pause) {
+
+            response.pause();
+            self._rp_resolve(response);
 
         } else {
 
@@ -146,6 +159,14 @@ module.exports = function (options) {
 
         }
 
+    };
+
+    plumbing.removeListeners = function () {
+        var self = this;
+        if (self._rp_options.pause) {
+            self.removeListener("error", plumbing.handleError);
+            self.removeListener("response", plumbing.handleResponse);
+        }
     };
 
     plumbing.exposePromiseMethod = function (exposeTo, bindTo, promisePropertyKey, methodToExpose, exposeAs) {

--- a/lib/plumbing.js
+++ b/lib/plumbing.js
@@ -33,6 +33,11 @@ module.exports = function (options) {
 
         var self = this;
 
+        self._rp_options = requestOptions;
+        self._rp_options.simple = requestOptions.simple !== false;
+        self._rp_options.resolveWithFullResponse = requestOptions.resolveWithFullResponse === true;
+        self._rp_options.transform2xxOnly = requestOptions.transform2xxOnly === true;
+
         self._rp_promise = new PromiseImpl(function (resolve, reject) {
             self._rp_resolve = resolve;
             self._rp_reject = reject;
@@ -51,11 +56,6 @@ module.exports = function (options) {
         }
 
         requestOptions.transform = requestOptions.transform || plumbing.defaultTransformations[requestOptions.method];
-
-        self._rp_options = requestOptions;
-        self._rp_options.simple = requestOptions.simple !== false;
-        self._rp_options.resolveWithFullResponse = requestOptions.resolveWithFullResponse === true;
-        self._rp_options.transform2xxOnly = requestOptions.transform2xxOnly === true;
 
     };
 
@@ -80,13 +80,33 @@ module.exports = function (options) {
             }
         }
 
-        var is2xx = !err && /^2/.test('' + response.statusCode);
-
         if (err) {
+            plumbing.handleError.call(self, err, response);
+        } else {
+            plumbing.handleResponse.call(self, response, body);
+        }
 
-            self._rp_reject(new errors.RequestError(err, self._rp_options, response));
+        if (origCallbackThrewException) {
+            throw thrownException;
+        }
 
-        } else if (self._rp_options.simple && !is2xx) {
+    };
+
+    plumbing.handleError = function (err, response) {
+
+        var self = this;
+
+        self._rp_reject(new errors.RequestError(err, self._rp_options, response));
+
+    };
+
+    plumbing.handleResponse = function (response, body) {
+
+        var self = this;
+
+        var is2xx = /^2/.test('' + response.statusCode);
+
+        if (self._rp_options.simple && !is2xx) {
 
             if (isFunction(self._rp_options.transform) && self._rp_options.transform2xxOnly === false) {
 
@@ -124,10 +144,6 @@ module.exports = function (options) {
                 self._rp_resolve(body);
             }
 
-        }
-
-        if (origCallbackThrewException) {
-            throw thrownException;
         }
 
     };


### PR DESCRIPTION
See request/request-promise#90. The particular implementation details are:

 - `transform` and `resolveWithFullResponse` are always ignored.
 - The stream is **not** paused if the promise rejects (i.e. if `simple = true` and the response is a 404), so the response cannot be streamed in that case. This is a limitation, but 99% of the time users aren't interested in the error body, so that'd be a memory leak unless they make sure `stream.resume()` is called on rejections. And if you really need to stream error responses, you can use `simple = false`.

[Proposed documentation and examples](https://github.com/request/request-promise/compare/master...botgram:feature-pause?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8) for the option:

``` js
var options = {
    uri: 'http://my-server/big-file.zip',
    pause: true,
};
rp(options)
    .then(function (response) {
        console.log("Downloading %s bytes file...", response.headers["content-length"]);
        response.pipe(fs.createWriteStream("downloaded.zip"));
        response.on("end", () => console.log("Downloaded."));
    })
    .catch(function (err) {
        // Request failed...
    });
```

- `pause = false` which is a boolean that when set, the promise will be resolved with the raw response stream ([`http.IncomingMessage`](https://nodejs.org/docs/latest/api/http.html#http_class_http_incomingmessage)) before the body arrives (e.g. when the `response` event fires). Implies `resolveWithFullResponse = true` and `transform = null`.
	- **Note:** The stream will be **paused** before the promise resolves, so that you can pipe or subscribe to the stream before any data gets lost. `.pipe()` and others resume it automatically, otherwise you may need to call `.resume()` manually, **even if you do nothing else with the stream**.
	- **Note 2:** You don't need to do anything if the promise rejects, as the stream is not paused. But this means **it's unsafe to stream the response in that case**, as data might get lost.

The implementation is in the second commit, the first is just a refactor to prepare for the changes.