### PR TITLE
[Security] Update lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.12"
   },
   "peerDependencies": {
     "request": "^2.34"


### PR DESCRIPTION
Update lodash to patch prototype pollution vulnerability. This makes #19 obsolete.